### PR TITLE
Add metacritic function to query and retrive scores of games

### DIFF
--- a/discordbot/main.py
+++ b/discordbot/main.py
@@ -334,4 +334,51 @@ def motogpteam():
     return string_bot
 
 
+def get_metacritic(game):
+    platforms_to_metacritic = {
+        "ps5": "PS5",
+        "ps4": "PS4",
+        "ps3": "PS3",
+        "ps2": "PS2",
+        "xbox series x": "XBSX",
+        "xbox one": "XONE",
+        "xbox 360": "X360",
+        "xbox": "XBOX",
+        "switch": "Switch",
+        "pc": "PC",
+    }
+    game = game.lower()
+    selected_platform = None
+    for platform in platforms_to_metacritic.keys():
+        if platform in game:
+            selected_platform = platform
+            game = game.replace(selected_platform, "").strip()
+            selected_platform = platforms_to_metacritic[selected_platform]
+    for i in range(2):
+        url = f"https://www.metacritic.com/search/game/{game}/results?sort=relevancy&page={i}"
+        text = requests.get(url, headers=headers).text
+        soup = BeautifulSoup(text, "lxml")
+        li_tags = soup.find_all("li", class_=["result first_result", "result"])
+        for li_tag in li_tags:
+            platform = li_tag.find("span", class_="platform")
+            if not platform:
+                continue
+            platform = platform.text
+            game_name = li_tag.find("a", href=True).text.strip()
+            score = li_tag.find("span").text
+            platform_and_date = li_tag.find("p").text
+            platform_and_date = " ".join(platform_and_date.split())
+            a_tag = li_tag.find("a", href=True)
+            site = f"https://www.metacritic.com{a_tag['href']}"
+            output_string = (
+                f"Metacritic <{game_name} ({platform_and_date})>: {score} ~ {site}"
+            )
+            if not selected_platform:
+                return output_string
+            if selected_platform == platform:
+                return output_string
+    output_string = f"Metacritic <{game}>: no results."
+    return output_string
+
+
 client.run(token)

--- a/discordbot/main.py
+++ b/discordbot/main.py
@@ -334,6 +334,12 @@ def motogpteam():
     return string_bot
 
 
+@client.command()
+async def metacritic(ctx, *, game):
+    text = get_metacritic(game)
+    await ctx.send(text)
+
+
 def get_metacritic(game):
     platforms_to_metacritic = {
         "ps5": "PS5",


### PR DESCRIPTION
The command of the bot can be queried in two ways:

- By specifying the platform (e.g `]metacritic the witcher 3 wild hunt ps4`)
- By only specifying the name (e.g `]metacritic the witcher 3 wild hunt`)

In the first case, the user specifies a platform along with the game's name, the bot will try to find the exact match for that platform and display the corresponding score. (e.g `Metacritic <The Witcher 3: Wild Hunt (PS4 Game, 2015)>: 92 ~ https://www.metacritic.com/game/playstation-4/the-witcher-3-wild-hunt`).

In the second case, if the user only specifies the game's name without a platform, the bot will search for the game and display the score from the first result it finds. (e.g `Metacritic <The Witcher 3: Wild Hunt (PS4 Game, 2015)>: 92 ~ https://www.metacritic.com/game/playstation-4/the-witcher-3-wild-hunt`)